### PR TITLE
Resolves #2 : Add a filename input 

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,6 +162,12 @@
                 </div>
             </div>
 
+            <!-- filename Input -->
+            <div class="input-group data-field" data-type="filename Input">
+                <label for="filenameInput">FILENAME (optional)</label>
+                <input id="filenameInput" type="text" placeholder="nfc_filename">
+            </div>  
+
             <button id="generateButton" class="btn">Generate NFC Tag</button>
 
             <div id="outputSection" class="hidden">

--- a/script.js
+++ b/script.js
@@ -28,7 +28,8 @@ document.addEventListener('DOMContentLoaded', () => {
         mimeDataInput: document.getElementById('mimeDataInput'),
         facetimeInput: document.getElementById('facetimeInput'),
         addressInput: document.getElementById('addressInput'),
-        homeKitCodeInput: document.getElementById('homeKitCodeInput')
+        homeKitCodeInput: document.getElementById('homeKitCodeInput'),
+        filenameInput: document.getElementById('filenameInput')
     };
 
     let lastInputData = ''; // Store the last input data globally
@@ -730,9 +731,13 @@ Pages read: ${this.getNfcPageCount()}`;
     function generateFilename() {
         const tagType = document.getElementById('tagType').value;
         const sanitizedInputData = sanitizeFilename(lastInputData);
+        if (!inputs.filenameInput.value) { // Generate filename if not provided
         let filename = `nfc_${tagType.toLowerCase()}_${sanitizedInputData}`;
         if (filename.length > 50) {
             filename = filename.substring(0, 50);
+        }
+        }else{ // Use provided filename
+            filename = inputs.filenameInput.value;
         }
         return filename;
     }
@@ -870,17 +875,19 @@ Pages read: ${this.getNfcPageCount()}`;
 
         let filename = 'nfc_tag';
         const selectedType = tagTypeSelect.value;
-
-        if (lastInputData) {
-            const sanitizedInputData = sanitizeFilename(lastInputData);
-            filename = `nfc_${selectedType.toLowerCase()}_${sanitizedInputData}`;
-            if (filename.length > 50) {
-                filename = filename.substring(0, 50);
+        if (!filenameInput.value) { // Generate filename if not provided
+            if (lastInputData) {
+                const sanitizedInputData = sanitizeFilename(lastInputData);
+                filename = `nfc_${selectedType.toLowerCase()}_${sanitizedInputData}`;
+                if (filename.length > 50) {
+                    filename = filename.substring(0, 50);
+                }
+            } else {
+                filename = `nfc_${selectedType.toLowerCase()}`;
             }
-        } else {
-            filename = `nfc_${selectedType.toLowerCase()}`;
+        }else { // Use provided filename
+            filename = filenameInput.value;
         }
-
         a.download = `${filename}.nfc`;
         document.body.appendChild(a);
         a.click();


### PR DESCRIPTION
# ✨ Add Filename Input Field Before Download

Issue resolved : #2 

Description: This pull request introduces a new feature that allows users to name their files before downloading them. This enhancement streamlines the user workflow by eliminating the need to rename files post-download.

## Changes Made:

- Added an input field on the download interface for specifying the desired filename.
- Ensured the entered name is used as the filename during the download process.

**🚨 The connection between my web browser and my flipper don't work, so i couldn't check if the send to the flipper function works**

## How to Test:

- Navigate to the main interface.
- Enter a desired filename in the new input field.
- Click the download button and verify that the downloaded file uses the specified name.
- Click the send to Flipper button and verify that the downloaded file uses the specified name.
- Check without text in the filename input

## Checklist:

- [x] Code review completed
- [x] Testing instructions provided
- [x] Awaiting feedback from reviewers

